### PR TITLE
Small README styling changes for readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Vagrantfile
 
 ### conventions ###
 venv/
+venv-*/
 v/
 
 ### Frontend 

--- a/README.md
+++ b/README.md
@@ -16,36 +16,38 @@ Installing
 ---
 
 To install this application you need python3.
-Clone the repository
-`git clone <repository>`
-Launch a virtual environment, 
-`virtualenv -p python3 venv/ && source venv/bin/activate`
-install the dependencies with pip
-`pip install -r scripts/cre_sync/requirements.txt`
+Clone the repository:
+<pre>git clone <repository></pre>
+Launch a virtual environment:
+<pre>virtualenv -p python3 venv/ && source venv/bin/activate`</pre>
+Install the dependencies with pip:
+<pre>pip install -r scripts/cre_sync/requirements.txt</pre>
 
 Running
 -------
 
-To run the cli application, you can run `python cre.py --help`
+To run the CLI application, you can run
+<pre>python cre.py --help</pre>
 To download a remote cre spreadsheet locally you can run
-`python cre.py --review --from_spreadsheet <google sheets url>`
+<pre>python cre.py --review --from_spreadsheet <google sheets url></pre>
 
 To add a remote spreadsheet to your local database you can run
-`python cre_main.py --add --from_spreadsheet <google sheets url>`
+<pre>python cre_main.py --add --from_spreadsheet <google sheets url></pre>
 
 To run the web application for development you can run
-`FLASK_APP=cre.py flask run`
+<pre>FLASK_APP=cre.py flask run</pre>
 
 Alternatively, you can use the dockerfile with
-`docker build -f Dockerfile-dev -t csync . && docker run -it -p 5000:5000 csync`
+<pre>docker build -f Dockerfile-dev -t csync . && docker run -it -p 5000:5000 csync</pre>
 
 To run the web application for production you need gunicorn and you can run from within the cre_sync dir
-`gunicorn cre:app --log-file=-`
+<pre>gunicorn cre:app --log-file=-</pre>
 
 Developing
 ---
 
-You can run backend tests with `FLASK_APP=cre.py FLASK_CONFIG=test flask test`
+You can run backend tests with
+<pre>FLASK_APP=cre.py FLASK_CONFIG=test flask test</pre>
 You can run get a coverage report with `FLASK_APP=cre.py FLASK_CONFIG=test flask test --coverage`
 Try to keep the coverage above 70%
 
@@ -55,55 +57,55 @@ Repo Moved here from https://github.com/northdpole/www-project-integration-stand
 Development Notes
 ---
 
-add tests
-   ~ defs --- Done
-   ~ db -- Done
-   ~ parsers -- Done 
-   ~ mapping_add -- Done for important methods, -- argparse logic only remains
-   ~ spreadsheet_utils ~ -- Done
-   frontend
+- [ ] add tests
+- [x] defs 
+- [x] db 
+- [x] parsers 
+- [ ] mapping_add  ( done for important methods ) argparse logic only remains
+- [x] spreadsheet_utils
+- [ ]  frontend
 
-* ~ add parse from export format ~ Done
-* ~ add parse from export format where the root doc is a standard and it links to cres or groups ~ Done
-* ~ add parse from spreadsheet with unknown standards (for key,val in items add_standard) ~ Done
-* ~ merge spreadsheet to yaml and mapping add, they do the same thing ~ Done
-* ~ add the ability for standards to link other standards, then you can handle assigning CREs yourself ~ Done
-* ~ support importing yaml export files of more than 1 levels deep ~ Done
-* ~ add export for Standards unmapped to CREs as lone standards (useful for visibility) ~ Done
-* ~ add sparse_spreadsheet_export functionality one level of mapping per row, either everything that maps to standard X or everything that maps to CRE x ~ Done
-* ~ add parse from export format ~ Done
-* ~ add github actions ci ~ Done
-* ~ make into flask rest api ~ Done
-* ~   refer use case (search by cre) ~ Done
-* ~   search by standard ~ Done
-* ~ add the ability for a mapping document to have multiple yamls in it ~ Done
-* ~ add db integration of tags ~ Done
-* ~ add tags in db  (search by tag, export with tags etc) ~ Done 
-* add parser integration of tags (parse the new new new spreadsheet template which incorporates tags) ~ Done
-* ~ add search by tag in rest ~ Done
-* ~ add dockerfile ~ Done
-* ~ add conditional export (select the standards you want exported get mappings between them)  (gap analysis use case) ~ -- Done
-* ~ add flask cover command from here https://github.com/miguelgrinberg/flasky/blob/master/flasky.py#L33~ Done
-* ~ Make Standards versioned ~ -- Done
-* ~ write frontend  ~ Done
-* ~ make results per page a config item from env ~ Done
-* ~ migrate to new repo ~ Done
-* ~ add black autoformater ~ Done
-* ~ merge frontend changes to master ~ Done
-* ~ Typed Python? ~ Done
+- [x] add parse from export format 
+- [x] add parse from export format where the root doc is a standard and it links to cres or groups 
+- [x] add parse from spreadsheet with unknown standards (for key,val in items add_standard) 
+- [x] merge spreadsheet to yaml and mapping add, they do the same thing 
+- [x] add the ability for standards to link other standards, then you can handle assigning CREs yourself 
+- [x] support importing yaml export files of more than 1 levels deep 
+- [x] add export for Standards unmapped to CREs as lone standards (useful for visibility) 
+- [x] add sparse_spreadsheet_export functionality one level of mapping per row, either everything that maps to standard X or everything that maps to CRE x 
+- [x] add parse from export format 
+- [x] add github actions ci 
+- [x] make into flask rest api 
+- [x] > refer use case (search by cre) 
+- [x] > search by standard 
+- [x] add the ability for a mapping document to have multiple yamls in it 
+- [x] add db integration of tags 
+- [x] add tags in db  (search by tag, export with tags etc)  
+- [x] add parser integration of tags (parse the new new new spreadsheet template which incorporates tags) 
+- [x] add search by tag in rest 
+- [x] add dockerfile 
+- [x] add conditional export (select the standards you want exported get mappings between them)  (gap analysis use case) ~ -- Done
+- [x] add flask cover command from here https://github.com/miguelgrinberg/flasky/blob/master/flasky.py#L33
+- [x] Make Standards versioned ~ -- Done
+- [x] write frontend  
+- [x] make results per page a config item from env 
+- [x] migrate to new repo 
+- [x] add black autoformater 
+- [x] merge frontend changes to master 
+- [x] Typed Python? 
 
 = Future Considerations =
 
-* improve test coverage -- we are at 73%, let's increase to 80%
+- [ ] improve test coverage -- we are at 73%, let's increase to 80%
 
-* Make frontend show gap analysis
-* Make frontend export search results and gap analysis to spreadsheet (supply backend with an "export=True" arg)
-* Make frontned able to import from spreadsheet template.
-* Make frontend able to import from files
-* Make frontend able to import by filing in a form.
-* make pagination also for tag results and gap analysis
-* make library out of file format and spreadsheet template parsers
-* add more linkTypes, Child, Controls, Tests, others.
-* Add more Document types, Tool, Library
-* Figure a way to dynamically register new Custom Resource Definitions and register custom logic on what to do on import/export and search.
-* write docs and record usage gif
+- [ ] Make frontend show gap analysis
+- [ ] Make frontend export search results and gap analysis to spreadsheet (supply backend with an "export=True" arg)
+- [ ] Make frontned able to import from spreadsheet template.
+- [ ] Make frontend able to import from files
+- [ ] Make frontend able to import by filing in a form.
+- [ ] make pagination also for tag results and gap analysis
+- [ ] make library out of file format and spreadsheet template parsers
+- [ ] add more linkTypes, Child, Controls, Tests, others.
+- [ ] Add more Document types, Tool, Library
+- [ ] Figure a way to dynamically register new Custom Resource Definitions and register custom logic on what to do on import/export and search.
+- [ ] write docs and record usage gif

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Launch a virtual environment:
 <pre>virtualenv -p python3 venv/ && source venv/bin/activate`</pre>
 Install the dependencies with pip:
 <pre>pip install -r scripts/cre_sync/requirements.txt</pre>
+Copy sqlite database to required location
+<pre>cp cres/db.sqlite standards_cache.sqlite</pre>
+
 
 Running
 -------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Clone the repository:
 Launch a virtual environment:
 <pre>virtualenv -p python3 venv/ && source venv/bin/activate`</pre>
 Install the dependencies with pip:
-<pre>pip install -r scripts/cre_sync/requirements.txt</pre>
+<pre>pip install -r requirements.txt</pre>
 Copy sqlite database to required location
 <pre>cp cres/db.sqlite standards_cache.sqlite</pre>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,10 +4,10 @@ const { TsConfigPathsPlugin } = require('awesome-typescript-loader');
 
 module.exports = {
   mode: 'development',
-  context: path.join(__dirname, 'src'),
+  context: path.join(__dirname, 'application/frontend/src'),
   entry: ['./main.tsx'],
   output: {
-    path: path.join(__dirname, 'www'),
+    path: path.join(__dirname, 'application/frontend/www'),
     filename: 'bundle.js',
     publicPath: '/',
   },


### PR DESCRIPTION
- Replacing ~ done and not done with tick boxes
- Replace inline code commands with separate boxes, used <pre> instead of ``` as VSC shows it by default correct in the preview
- Added a git ignore for venv-* as I label my venv's ( getting weird errors because you're in the venv of another project has happened to often to me )
-  Added the copy of database command so users that see the project won't get errors because of an empty database