### PR TITLE
#81 : remove contains from nested view and add clickable links for each cre

### DIFF
--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -3,13 +3,14 @@ import './documentNode.scss';
 import React, { FunctionComponent, useMemo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
-import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF, TYPE_CONTAINS } from '../../const';
+import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF, TYPE_CONTAINS, TYPE_LINKED_TO } from '../../const';
 import { CRE, STANDARD } from '../../routes';
 import { Document } from '../../types';
 import { getDocumentDisplayName, groupLinksByType } from '../../utils';
 import { useEnvironment } from '../../hooks';
 import axios from 'axios';
 import { LoadingAndErrorIndicator } from '../LoadingAndErrorIndicator';
+import { getApiEndpoint, getInternalUrl } from '../../utils/document';
 
 interface DocumentNode {
   node: Document,
@@ -29,11 +30,12 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
   const id = isStandard ? node.name : node.id;
 
   var usedNode = nestedNode || node;
+  const hasExternalLink = Boolean(usedNode.hyperlink);
   const linksByType = useMemo(() => groupLinksByType(usedNode), [usedNode]);
 
   useEffect( () => {
     if ( !isStandard && linkTypesToNest.includes(linkType) ) {
-      axios.get(`${apiUrl}/id/${id}`)
+      axios.get(getApiEndpoint(node, apiUrl))
       .then(function (response) {
         setNestedNode(response.data.data);
         setExpanded(true);
@@ -46,9 +48,6 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
   }, [id]);
 
   if ( ( !usedNode.links || usedNode.links.length === 0)) {
-    const route = isStandard ? STANDARD : CRE;
-    const hasExternalLink = Boolean(usedNode.hyperlink);
-    var hyperlink = usedNode.hyperlink ? usedNode.hyperlink : ""
     const linkContent = (
       <>
         <i aria-hidden="true" className="circle icon"></i>
@@ -58,16 +57,11 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
     );
     return (
       <>
-
-        { hasExternalLink 
-          ? <p className={`title external-link document-node external square f1`}>
-              <a target="_blank" href={hyperlink}>
-                {linkContent}
-              </a>
-            </p>
-          : <div className={`title external-link document-node f2`}>
-              <Link to={`${route}/${id}`}>{linkContent}</Link></div>
-        }
+        <div className={`title external-link document-node f2`}>
+          <Link to={getInternalUrl(usedNode)}>
+            {linkContent}
+          </Link>
+        </div>
         <div className={`content`}></div>
       </>
     );
@@ -81,11 +75,19 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
       <LoadingAndErrorIndicator loading={loading} error={error} />
       <div className={`title${active} document-node`} onClick={() => setExpanded(!expanded)}>
         <i aria-hidden="true" className="dropdown icon"></i>
-        <a href={usedNode.hyperlink}>
+        <Link to={getInternalUrl(usedNode)}>
           { getDocumentDisplayName(usedNode) }
-        </a>
+        </Link>
       </div>
       <div className={`content${active} document-node`}>
+        { expanded && hasExternalLink &&
+          <>
+            <span>
+              Reference: 
+            </span>
+            <a href={usedNode.hyperlink} target="_blank"> { usedNode.hyperlink }</a>
+          </>
+        }
         { expanded 
           && Object.entries(linksByType)
             .filter( ([type, _]) => !linkTypesExcludedInNesting.includes(type) )
@@ -93,10 +95,7 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
             return (
               <div className="document-node__link-type-container" key={type}>
                 <div>
-                  { usedNode.hyperlink
-                    ? <a href={usedNode.hyperlink}> {usedNode.name} - {usedNode.section} </a>
-                    : <span > {usedNode.name} - {usedNode.section} </span>
-                  }
+                  <span > {usedNode.name} - {usedNode.section} </span>
                   <b> {DOCUMENT_TYPE_NAMES[type]}</b>:
                 </div>
                 <div>

--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -52,20 +52,21 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
     const linkContent = (
       <>
         <i aria-hidden="true" className="circle icon"></i>
-        {getDocumentDisplayName(usedNode)}
+        { getDocumentDisplayName(usedNode) }
         <i aria-hidden="true" className={`${hasExternalLink ? 'external' : 'external square'} icon`}></i>
       </>
     );
     return (
       <>
 
-        {hasExternalLink ? (
-          <p className={`title external-link document-node external square f1`}>
-            <a target="_blank" href={hyperlink}>
-              {linkContent}
-            </a></p>
-        ) : <div className={`title external-link document-node f2`}>
-            <Link to={`${route}/${id}`}>{linkContent}</Link></div>
+        { hasExternalLink 
+          ? <p className={`title external-link document-node external square f1`}>
+              <a target="_blank" href={hyperlink}>
+                {linkContent}
+              </a>
+            </p>
+          : <div className={`title external-link document-node f2`}>
+              <Link to={`${route}/${id}`}>{linkContent}</Link></div>
         }
         <div className={`content`}></div>
       </>
@@ -81,14 +82,14 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
       <div className={`title${active} document-node`} onClick={() => setExpanded(!expanded)}>
         <i aria-hidden="true" className="dropdown icon"></i>
         <a href={usedNode.hyperlink}>
-          {getDocumentDisplayName(usedNode)}
+          { getDocumentDisplayName(usedNode) }
         </a>
       </div>
       <div className={`content${active} document-node`}>
         { expanded 
           && Object.entries(linksByType)
-            .filter( ([type, _]) => !linkTypesExcludedInNesting.includes(type))
-            .map(([type, links]) => {
+            .filter( ([type, _]) => !linkTypesExcludedInNesting.includes(type) )
+            .map( ([type, links] ) => {
             return (
               <div className="document-node__link-type-container" key={type}>
                 <div>

--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -4,7 +4,6 @@ import React, { FunctionComponent, useMemo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF, TYPE_CONTAINS, TYPE_LINKED_TO } from '../../const';
-import { CRE, STANDARD } from '../../routes';
 import { Document } from '../../types';
 import { getDocumentDisplayName, groupLinksByType } from '../../utils';
 import { useEnvironment } from '../../hooks';
@@ -35,13 +34,16 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
 
   useEffect( () => {
     if ( !isStandard && linkTypesToNest.includes(linkType) ) {
+      setLoading(true);
       axios.get(getApiEndpoint(node, apiUrl))
       .then(function (response) {
+        setLoading(false);
         setNestedNode(response.data.data);
         setExpanded(true);
         setError('');
       })
       .catch(function (axiosError) {
+        setLoading(false);
         setError(axiosError);
       });
     }

--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -48,18 +48,12 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
   }, [id]);
 
   if ( ( !usedNode.links || usedNode.links.length === 0)) {
-    const linkContent = (
-      <>
-        <i aria-hidden="true" className="circle icon"></i>
-        { getDocumentDisplayName(usedNode) }
-        <i aria-hidden="true" className={`${hasExternalLink ? 'external' : 'external square'} icon`}></i>
-      </>
-    );
     return (
       <>
         <div className={`title external-link document-node f2`}>
           <Link to={getInternalUrl(usedNode)}>
-            {linkContent}
+            <i aria-hidden="true" className="circle icon"></i>
+            { getDocumentDisplayName(usedNode) }
           </Link>
         </div>
         <div className={`content`}></div>

--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -3,7 +3,7 @@ import './documentNode.scss';
 import React, { FunctionComponent, useMemo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
-import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF } from '../../const';
+import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF, TYPE_CONTAINS } from '../../const';
 import { CRE, STANDARD } from '../../routes';
 import { Document } from '../../types';
 import { getDocumentDisplayName, groupLinksByType } from '../../utils';
@@ -16,7 +16,8 @@ interface DocumentNode {
   linkType: string;
 }
 
-const nestedDocumentLinkTypes = [TYPE_IS_PART_OF]
+const linkTypesToNest = [TYPE_IS_PART_OF]
+const linkTypesExcludedInNesting = [TYPE_CONTAINS]
 
 export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }) => {
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -31,7 +32,7 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
   const linksByType = useMemo(() => groupLinksByType(usedNode), [usedNode]);
 
   useEffect( () => {
-    if ( !isStandard && nestedDocumentLinkTypes.includes(linkType) ) {
+    if ( !isStandard && linkTypesToNest.includes(linkType) ) {
       axios.get(`${apiUrl}/id/${id}`)
       .then(function (response) {
         setNestedNode(response.data.data);
@@ -84,8 +85,10 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
         </a>
       </div>
       <div className={`content${active} document-node`}>
-        {expanded &&
-          Object.entries(linksByType).map(([type, links]) => {
+        { expanded 
+          && Object.entries(linksByType)
+            .filter( ([type, _]) => !linkTypesExcludedInNesting.includes(type))
+            .map(([type, links]) => {
             return (
               <div className="document-node__link-type-container" key={type}>
                 <div>

--- a/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
+++ b/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
@@ -45,12 +45,18 @@ export const CommonRequirementEnumeration = () => {
           <h4 className="cre-page__heading">{cre.name}</h4>
           <h5 className="cre-page__sub-heading">{cre.id}</h5>
           <div className="cre-page__description">{cre.description}</div>
+          { cre && cre.hyperlink &&
+            <>
+              <span>Reference: </span>
+              <a href={cre?.hyperlink} target="_blank"> { cre.hyperlink }</a>
+            </>
+          }
           <div className="cre-page__tags">Tags: {cre.tags?cre.tags.map((tag) => (<b>{tag} </b>)):""}</div>
           <div className="cre-page__links-container">
             {Object.keys(linksByType).length > 0 &&
               Object.entries(linksByType).map(([type, links]) => (
                 <div className="cre-page__links" key={type}>
-                  <div className="cre-page__links-header">
+                  <div className="cre-page__links-eader">
                     {cre.id}: {cre.name} <b>{DOCUMENT_TYPE_NAMES[type]}</b>:
                   </div>
                   {links.map((link, i) => (

--- a/application/frontend/src/pages/Search/components/BodyText.tsx
+++ b/application/frontend/src/pages/Search/components/BodyText.tsx
@@ -61,9 +61,9 @@ export const SearchBody = () => {
       </h2>
       <p>
         See the CRE search bar (beta version). Try searching for
-        <a href="https://www.opencre.org/standard/Top10%202017"> Top10 2017 </a>
+        <a href="/standard/Top10%202017"> Top10 2017 </a>
         as standard and click around, or
-        <a href="https://www.opencre.org/cre/482-866"> 482-866 </a>
+        <a href="/cre/482-866"> 482-866 </a>
         as CRE-ID, to get an idea.
       </p>
     </div>

--- a/application/frontend/src/pages/Standard/StandardSection.tsx
+++ b/application/frontend/src/pages/Standard/StandardSection.tsx
@@ -1,0 +1,85 @@
+import './standard.scss';
+
+import React, { useEffect, useState, useMemo } from 'react';
+import { useQuery } from 'react-query';
+import { useParams } from 'react-router-dom';
+import { Pagination } from 'semantic-ui-react';
+
+import { DocumentNode } from '../../components/DocumentNode';
+import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
+import { useEnvironment } from '../../hooks';
+import { Document } from '../../types';
+import { groupLinksByType } from '../../utils';
+import { DOCUMENT_TYPE_NAMES } from '../../const';
+
+
+export const StandardSection = () => {
+  const { id, section } = useParams();
+  const { apiUrl } = useEnvironment();
+  const [page, setPage] = useState<number>(1);
+  const [loading, setLoading] = useState<boolean>(false);
+  
+  const getSectionParameter = (): string => {
+    return section ? `&section=${encodeURIComponent(section)}` : '';
+  }
+
+  const { error, data, refetch } = useQuery<{ standards: Document[]; total_pages: number; page: number }, string>(
+    'standard section',
+    () => fetch(`${apiUrl}/standard/${id}?page=${page}${getSectionParameter()}`).then((res) => res.json()),
+    {
+      retry: false,
+      enabled: false,
+      onSettled: () => {
+        setLoading(false);
+      },
+    }
+  );
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    setLoading(true);
+    refetch();
+  }, [page, id]);
+
+  const documents = data ?.standards || [];
+  const document = documents[0];
+  const linksByType = useMemo(() => (document ? groupLinksByType(document) : {}), [document]);
+
+  return (
+    <>
+      <div className="standard-page">
+        <h4 className="standard-page__heading">{id}</h4>
+        <h5 className="standard-page__sub-heading">Section: {document?.section}</h5>
+        <LoadingAndErrorIndicator loading={loading} error={error} />
+        {!loading &&
+          !error &&
+          <div className="cre-page__links-container">
+            {Object.keys(linksByType).length > 0 &&
+              Object.entries(linksByType).map(([type, links]) => (
+                <div className="cre-page__links" key={type}>
+                  <div className="cre-page__links-header">
+                    {document.name} - {document.section} <b>{DOCUMENT_TYPE_NAMES[type]}</b>:
+                  </div>
+                  {links.map((link, i) => (
+                    <div key={i} className="accordion ui fluid styled cre-page__links-container">
+                      <DocumentNode node={link.document} linkType={type} />
+                    </div>
+                  ))}
+                </div>
+              ))}
+          </div>
+        }
+
+        {data && data.total_pages > 0 && (
+          <div className="pagination-container">
+            <Pagination
+              defaultActivePage={1}
+              onPageChange={(_, d) => setPage(d.activePage as number)}
+              totalPages={data.total_pages}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/application/frontend/src/pages/Standard/StandardSection.tsx
+++ b/application/frontend/src/pages/Standard/StandardSection.tsx
@@ -50,6 +50,12 @@ export const StandardSection = () => {
       <div className="standard-page">
         <h4 className="standard-page__heading">{id}</h4>
         <h5 className="standard-page__sub-heading">Section: {document?.section}</h5>
+        { document && document.hyperlink &&
+            <>
+              <span>Reference: </span>
+              <a href={document?.hyperlink} target="_blank"> { document.hyperlink }</a>
+            </>
+          }
         <LoadingAndErrorIndicator loading={loading} error={error} />
         {!loading &&
           !error &&

--- a/application/frontend/src/pages/Standard/standard.scss
+++ b/application/frontend/src/pages/Standard/standard.scss
@@ -13,4 +13,9 @@
     font-size: 2rem;
     margin-bottom: 0px;
   }
+  &__sub-heading {
+    color: #999;
+    margin-top: 0px;
+    font-size: 1.2rem;
+  }
 }

--- a/application/frontend/src/routes.tsx
+++ b/application/frontend/src/routes.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { CommonRequirementEnumeration, Graph, Search, Standard } from './pages';
 import { SearchName } from './pages/Search/SearchName';
+import { StandardSection } from './pages/Standard/StandardSection';
 
 export interface IRoute {
   // The url to this route
@@ -14,6 +15,7 @@ export interface IRoute {
 
 export const INDEX = '/';
 export const STANDARD = '/standard';
+export const SECTION = '/section';
 export const SEARCH = '/search';
 export const CRE = '/cre';
 export const GRAPH = '/graph';
@@ -23,6 +25,11 @@ export const ROUTES: IRoute[] = [
     path: INDEX,
     component: Search,
     showHeader: false,
+  },
+  {
+    path: `${STANDARD}/:id${SECTION}/:section`,
+    component: StandardSection,
+    showHeader: true,
   },
   {
     path: `${STANDARD}/:id`,

--- a/application/frontend/src/utils/document.ts
+++ b/application/frontend/src/utils/document.ts
@@ -17,3 +17,27 @@ export const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => 
     previous[group].push(currentItem);
     return previous;
 }, {} as Record<K, T[]>);
+
+export const getInternalUrl = (doc: Document): String => {
+  if (doc.doctype === 'Standard') {
+    var standardAPIPath = `/standard/${doc.name}/`;
+    if ( doc && doc.section){
+      standardAPIPath += `section/${encodeURIComponent(doc.section)}`;
+    }
+    return standardAPIPath
+  }
+
+  return `/cre/${doc.id}`
+}
+
+export const getApiEndpoint = (doc: Document, apiUrl: string): string => {
+  if (doc.doctype === 'Standard') {
+    var standardAPIPath = `${apiUrl}/standard/${doc.name}`;
+    if ( doc && doc.section){
+      standardAPIPath += `?section=${encodeURIComponent(doc.section)}`;
+    }
+    return standardAPIPath
+  }
+  
+  return `${apiUrl}/id/${doc.id}`
+}

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -66,7 +66,9 @@ def find_by_name(crename: str) -> Any:
 # @cache.cached(timeout=50)
 def find_standard_by_name(sname: str) -> Any:
     database = db.Standard_collection()
-    opt_section = urllib.parse.unquote(request.args.get("section"))
+    opt_section = (request.args.get("section"))
+    if (opt_section):
+        opt_section = urllib.parse.unquote(opt_section)
     opt_subsection = request.args.get("subsection")
     opt_hyperlink = request.args.get("hyperlink")
     page = 1

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -1,6 +1,7 @@
 # type: ignore
 # silence mypy for the routes file
 import os
+import urllib.parse
 from typing import Any
 
 from flask import (
@@ -65,7 +66,7 @@ def find_by_name(crename: str) -> Any:
 # @cache.cached(timeout=50)
 def find_standard_by_name(sname: str) -> Any:
     database = db.Standard_collection()
-    opt_section = request.args.get("section")
+    opt_section = urllib.parse.unquote(request.args.get("section"))
     opt_subsection = request.args.get("subsection")
     opt_hyperlink = request.args.get("hyperlink")
     page = 1

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,9 +56,11 @@ module.exports = {
 };
 
 module.exports.devServer = {
+  historyApiFallback: {
+    disableDotRule: true
+  },
   contentBase: './www',
   port: 9001,
-  historyApiFallback: true,
 };
 
 module.exports.devtool = 'inline-source-map';


### PR DESCRIPTION
FIX #81
- Excluded document with 'contains' type from the nested views
- Added a separate text for external URL (i.e. the buttons will no longer link to external sources, now the URL will be shown on the page of the topic itself or if shown in a nested way)
- Added separate pages for sections of a standard

All standards, CRE's and sections of standards have their own page now.