### PR TITLE
87 mitigate cyclic nesting when related topic are nested

### DIFF
--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -3,7 +3,7 @@ import './documentNode.scss';
 import React, { FunctionComponent, useMemo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
-import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF, TYPE_CONTAINS, TYPE_LINKED_TO } from '../../const';
+import { DOCUMENT_TYPE_NAMES, TYPE_IS_PART_OF, TYPE_CONTAINS, TYPE_LINKED_TO, TYPE_RELATED } from '../../const';
 import { Document } from '../../types';
 import { getDocumentDisplayName, groupLinksByType } from '../../utils';
 import { useEnvironment } from '../../hooks';
@@ -16,8 +16,9 @@ interface DocumentNode {
   linkType: string;
 }
 
-const linkTypesToNest = [TYPE_IS_PART_OF]
+const linkTypesToNest = [TYPE_IS_PART_OF, TYPE_RELATED]
 const linkTypesExcludedInNesting = [TYPE_CONTAINS]
+const linkTypesExcludedWhenNestingRelatedTo = [TYPE_RELATED, TYPE_IS_PART_OF, TYPE_CONTAINS]
 
 export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }) => {
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -86,7 +87,8 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({ node, linkType }
         }
         { expanded 
           && Object.entries(linksByType)
-            .filter( ([type, _]) => !linkTypesExcludedInNesting.includes(type) )
+            .filter( ([type, _]) => !linkTypesExcludedInNesting.includes(type))
+            .filter( ([type, _]) => type == TYPE_RELATED ? !linkTypesExcludedWhenNestingRelatedTo.includes(type) : true)
             .map( ([type, links] ) => {
             return (
               <div className="document-node__link-type-container" key={type}>

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -66,7 +66,7 @@ def find_by_name(crename: str) -> Any:
 # @cache.cached(timeout=50)
 def find_standard_by_name(sname: str) -> Any:
     database = db.Standard_collection()
-    opt_section = (request.args.get("section"))
+    opt_section = request.args.get("section")
     if (opt_section):
         opt_section = urllib.parse.unquote(opt_section)
     opt_subsection = request.args.get("subsection")

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -67,7 +67,7 @@ def find_by_name(crename: str) -> Any:
 def find_standard_by_name(sname: str) -> Any:
     database = db.Standard_collection()
     opt_section = request.args.get("section")
-    if (opt_section):
+    if opt_section:
         opt_section = urllib.parse.unquote(opt_section)
     opt_subsection = request.args.get("subsection")
     opt_hyperlink = request.args.get("hyperlink")


### PR DESCRIPTION
Fix #87

- Add nesting for link type "related"
- Topics nested in linktype "related" should only contain "linked" linkType (i.e. not contains / related / is part of)
- When there are no links available for a topic we'll not show it as a dropdown, as there are no links to show ( e.g. if a topic is nested in an "is related" linktype and only contains other links with "contains" or "is part of" as link types, which should not be shown as described in #87 and #81 ).


NOTE: we might want to do the retrieval of nested documents in the backend, now it fires 15+ requests for retrieving the nested documents ( depending on how many documents it links to ). Which is not ideal, but it works ;) 