### PR TITLE
Visual fixes for mobile view (#31)

### DIFF
--- a/application/frontend/src/App.tsx
+++ b/application/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import './app.scss';
 
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { Toaster } from 'react-hot-toast';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter } from 'react-router-dom';
@@ -9,19 +9,16 @@ import { MainContentArea } from './scaffolding';
 
 const queryClient = new QueryClient();
 
-interface IAppProps {}
-
-const App: FunctionComponent<IAppProps> = () => {
-  return (
-    <div className="app">
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <Toaster />
-          <MainContentArea />
-        </BrowserRouter>
-      </QueryClientProvider>
-    </div>
-  );
-};
+const App = () => (
+  <div className="app">
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Toaster />
+        <MainContentArea />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </div>
+);
 
 export default App;
+

--- a/application/frontend/src/app.scss
+++ b/application/frontend/src/app.scss
@@ -1,12 +1,31 @@
-.app {
-  height: 100vh;
-  width: 100vw;
-  margin:auto;
+
+* {
+  box-sizing: border-box;
 }
 
-.pagination-container {
+html,
+body {
+  height: 100%;
   width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  text-size-adjust: 100%;
+}
+
+body {
+  background-color: white;
+}
+
+.mount {
   display: flex;
-  justify-content: center;
-  padding-top: 10px;
+  justify-content: flex-start;
+  align-items: stretch;
+  flex-direction: row-reverse;
+  height: 100vh;
+  width: 100vw;
+  position: relative;
+  z-index: 1;
 }

--- a/application/frontend/src/index.html
+++ b/application/frontend/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no shrink-to-fit=no">
   <title>CRE</title>
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.1/dist/semantic.min.css" />
 </head>

--- a/application/frontend/src/pages/Search/components/BodyText.scss
+++ b/application/frontend/src/pages/Search/components/BodyText.scss
@@ -1,8 +1,8 @@
 .index-text {
     margin-top: 2rem;
-    width: 67%;
+    padding: 15px;
+    width: 70%;
     background: white;
-    padding: 1%;
 }
 
 // mobile

--- a/application/frontend/src/pages/Search/components/BodyText.scss
+++ b/application/frontend/src/pages/Search/components/BodyText.scss
@@ -1,6 +1,14 @@
-.index-text{
+.index-text {
     margin-top: 2rem;
     width: 67%;
     background: white;
     padding: 1%;
 }
+
+// mobile
+@media (min-width: 0px) and (max-width: 599px) {
+    .index-text {
+        width: 90%;
+    }
+}
+

--- a/application/frontend/src/pages/Search/components/SearchBar.scss
+++ b/application/frontend/src/pages/Search/components/SearchBar.scss
@@ -1,6 +1,9 @@
 #SearchBar {
   margin: auto;
+  padding-bottom: 7px;
 }
+
 #SearchButton{
   margin: auto;
+  padding-bottom: 7px;
 }

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -5,6 +5,8 @@
   align-items: center;
   flex-direction: column;
   justify-content: center;
+  padding-top: 40px;
+  padding-bottom: 40px;
 
   .search-page__heading {
     text-align: center;
@@ -22,17 +24,8 @@
   }
 }
 
-.cre-page {
-  .standard-page__heading {
-    color: white;
-  }
+// mobile
+.search-page {
+  padding-top: 30px;
+  padding-bottom: 30px;
 }
-
-.SearchBar {
-  margin: auto;
-}
-
-.Search{
-  margin: auto;
-}
-

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -25,7 +25,9 @@
 }
 
 // mobile
-.search-page {
-  padding-top: 30px;
-  padding-bottom: 30px;
+@media (min-width: 0px) and (max-width: 599px) {
+  .search-page {
+    padding-top: 30px;
+    padding-bottom: 30px;
+  }
 }

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -8,13 +8,11 @@
 
   .search-page__heading {
     text-align: center;
-    font-size: 4rem !important;
   }
 
   .search-page__heading,
   .search-page__sub-heading {
     color: white;
-    font-weight: 300 !important;
   }
 
   .search-page__sub-heading {
@@ -23,9 +21,18 @@
     color: #eee;
   }
 }
+
+.cre-page {
+  .standard-page__heading {
+    color: white;
+  }
+}
+
 .SearchBar {
   margin: auto;
 }
+
 .Search{
   margin: auto;
 }
+

--- a/application/frontend/src/pages/Standard/standard.scss
+++ b/application/frontend/src/pages/Standard/standard.scss
@@ -9,6 +9,9 @@
 
   .pagination-container {
     margin-top: 15px;
+    display: flex;
+    justify-content: center;
+
   }
 }
 

--- a/application/frontend/src/pages/Standard/standard.scss
+++ b/application/frontend/src/pages/Standard/standard.scss
@@ -6,6 +6,10 @@
   &__links-container {
     margin-top: 10px;
   }
+
+  .pagination-container {
+    margin-top: 15px;
+  }
 }
 
 .standard-page .standard-page {
@@ -17,5 +21,12 @@
     color: #999;
     margin-top: 0px;
     font-size: 1.2rem;
+  }
+}
+
+// mobile
+@media (min-width: 0px) and (max-width: 599px) {
+  .standard-page__links-container {
+      word-break: break-word;
   }
 }

--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -1,4 +1,5 @@
 .header__nav-bar {
+
   &.ui.secondary.menu {
     margin-top: 0px;
     border-bottom: none;
@@ -7,7 +8,6 @@
     padding-left: 20px;
 
     .item {
-      // padding: 0px !important;
       .ui.form {
         .fields {
           margin-bottom: 0px !important;
@@ -48,3 +48,22 @@
     }
   }
 }
+
+
+// mobile
+@media (min-width: 0px) and (max-width: 599px) {
+
+  .ui.menu:not(.vertical) .right.menu {
+    display: block;
+  }
+
+  .header__nav-bar {
+    flex-wrap: wrap;
+
+    &__link {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+  }
+}
+


### PR DESCRIPTION

#### What does this PR do?

Adds visual fixes for the landing page in mobile, as well as various other small visual fixes on other pages.

fixes #31 

Specific items fixed:

- landing page content was not spanning the entire width on mobile (css resets added, removed some overrides etc)
- landing page content was too "thin" on mobile
- links on search results were overflowing container - added word wrapping
- issues with search bar on 2nd page (was overflowing off the screen) on mobile

##### Screenshots

left is before, right is after.

<img width="1390" alt="Screenshot 2021-09-23 at 01 18 16" src="https://user-images.githubusercontent.com/4358045/134439151-ca0224e2-63e2-4f24-9078-6e83890cd919.png">

<img width="740" alt="Screenshot 2021-09-23 at 01 20 12" src="https://user-images.githubusercontent.com/4358045/134439166-0e9e73f0-05f0-4376-b3e7-6e04c5bceb7f.png">

<img width="763" alt="Screenshot 2021-09-23 at 01 24 07" src="https://user-images.githubusercontent.com/4358045/134439172-a24683e2-f1fd-480f-904e-0c6022324823.png">




