### PR TITLE
Fixes reload hack

### DIFF
--- a/application/frontend/src/const.ts
+++ b/application/frontend/src/const.ts
@@ -13,3 +13,11 @@ export const DOCUMENT_TYPE_NAMES = {
   [TYPE_CONTAINS]: "contains",
   [TYPE_RELATED]: "is related to",
 };
+
+// Routes
+export const INDEX = '/';
+export const STANDARD = '/standard';
+export const SECTION = '/section';
+export const SEARCH = '/search';
+export const CRE = '/cre';
+export const GRAPH = '/graph';

--- a/application/frontend/src/pages/Search/SearchName.tsx
+++ b/application/frontend/src/pages/Search/SearchName.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import axios from 'axios';
 
 import { useEnvironment } from '../../hooks';
-import axios from 'axios';
-import { DocumentNode } from '../../components/DocumentNode';
 import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
 import { groupBy } from '../../utils/document';
 import { Document } from '../../types';
+
+import { SearchResults } from './components/SearchResults';
 
 const CRE = "CRE";
 const STANDARD = "Standard";
@@ -18,7 +19,7 @@ export const SearchName = () => {
   const [documents, setDocuments] = useState<Document[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect( () => {
+  useEffect(() => {
     setLoading(true);
     axios.get(`${apiUrl}/text_search`, {params: {text: searchTerm}})
         .then(function (response) {
@@ -32,37 +33,25 @@ export const SearchName = () => {
         }).finally( () => {
             setLoading(false);
         });
-  }, []);
+  }, [searchTerm]);
 
   const groupedByType = groupBy(documents, doc => doc.doctype);
 
-  const RenderDocuments = ({ documentsToRender}) => {
-    return (
-        <div>
-            {
-            documentsToRender.length != 0
-            && documentsToRender.map((document, i) => (
-                <div key={i} className="accordion ui fluid styled standard-page__links-container">
-                    <DocumentNode node={document} linkType={"Standard"}/>
-                </div>
-            ))}
-        </div>
-    )
-  }
-
   return (
     <div className="cre-page">
-        <h1 className="standard-page__heading">Results matching : <i>{searchTerm}</i></h1>
+        <h1 className="standard-page__heading">
+            Results matching : <i>{searchTerm}</i>
+        </h1>
         <LoadingAndErrorIndicator loading={loading} error={error} />
-        { !loading && !error &&
+        {!loading && !error &&
             <div className="ui grid">
                 <div className="eight wide column">
                     <h1 className="standard-page__heading">Related CRE's</h1>
-                    { groupedByType[CRE] && <RenderDocuments documentsToRender={groupedByType[CRE]}/> }
+                    {groupedByType[CRE] && <SearchResults results={groupedByType[CRE]}/>}
                 </div>
                 <div className="eight wide column">
                     <h1 className="standard-page__heading">Related standards</h1>
-                    { groupedByType[STANDARD] && <RenderDocuments documentsToRender={groupedByType[STANDARD]}/>}
+                    {groupedByType[STANDARD] && <SearchResults results={groupedByType[STANDARD]}/>}
                 </div>
             </div>
         }

--- a/application/frontend/src/pages/Search/components/BodyText.tsx
+++ b/application/frontend/src/pages/Search/components/BodyText.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, Dropdown, Form, Icon, Input } from 'semantic-ui-react';
 
-import { CRE, STANDARD } from '../../../routes';
+import { CRE, STANDARD } from '../../../const';
 import './BodyText.scss';
 
 export const SearchBody = () => {

--- a/application/frontend/src/pages/Search/components/SearchBar.tsx
+++ b/application/frontend/src/pages/Search/components/SearchBar.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, Dropdown, Form, Icon, Input } from 'semantic-ui-react';
 
-import { CRE, STANDARD, SEARCH } from '../../../routes';
+import { STANDARD, CRE, SEARCH } from '../../../const';
+
 import './SearchBar.scss'
 
 const SEARCH_TYPES = [

--- a/application/frontend/src/pages/Search/components/SearchBar.tsx
+++ b/application/frontend/src/pages/Search/components/SearchBar.tsx
@@ -2,15 +2,15 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, Dropdown, Form, Icon, Input } from 'semantic-ui-react';
 
-import { STANDARD, CRE, SEARCH } from '../../../const';
+import { CRE, SEARCH, STANDARD } from '../../../const';
 
 import './SearchBar.scss'
 
-const SEARCH_TYPES = [
-  { key: 'topicText', text: 'Topic text', value: 'topicText' },
-  { key: 'standard', text: 'Standard', value: 'standard' },
-  { key: 'creId', text: 'CRE ID', value: 'creId' },
-];
+const SEARCH_TYPES = {
+  topicText: { key: 'topicText', text: 'Topic text', value: 'topicText', path: SEARCH },
+  standard: { key: 'standard', text: 'Standard', value: 'standard', path: STANDARD },
+  creId: { key: 'creId', text: 'CRE ID', value: 'creId', path: CRE  },
+};
 
 interface SearchBarState {
   term: string;
@@ -18,26 +18,18 @@ interface SearchBarState {
   error: string;
 }
 
-const DEFAULT_SEARCH_BAR_STATE: SearchBarState = { term: '', type: SEARCH_TYPES[0].key, error: '' };
+const DEFAULT_SEARCH_BAR_STATE: SearchBarState = { term: '', type: SEARCH_TYPES['topicText'].key, error: '' };
 
 export const SearchBar = () => {
   const [search, setSearch] = useState<SearchBarState>(DEFAULT_SEARCH_BAR_STATE);
   const history = useHistory();
 
   const onSubmit = () => {
-    var path
+    const {term, type} = search;
+
     if (Boolean(search.term)) {
-      if (search.type == "topicText") {
-        path = SEARCH
-      } else if (search.type === 'standard') {
-        path = STANDARD
-      } else if (search.type == 'creId') {
-        path = CRE
-      }
       setSearch(DEFAULT_SEARCH_BAR_STATE);
-      history.push(`${path}/${search.term}`);
-      window.location.href = window.location.href // horrible hack, but on the search results page
-                                                 //react will not do any requests otherwise
+      history.push(`${SEARCH_TYPES[type].path}/${term}`);
     } else {
       setSearch({
         ...search,
@@ -54,13 +46,9 @@ export const SearchBar = () => {
   }
 
   return (
-
-    <Form
-      onSubmit={onSubmit}
-    >
+    <Form onSubmit={onSubmit}>
       <Form.Group>
-        <Form.Field
-          id="SearchBar">
+        <Form.Field id="SearchBar">
           <Input
             error={Boolean(search.error)}
             value={search.term}
@@ -72,7 +60,7 @@ export const SearchBar = () => {
             }}
             label={
               <Dropdown
-                options={SEARCH_TYPES}
+                options={Object.values(SEARCH_TYPES)}
                 value={search.type}
                 onChange={onChange}
               />
@@ -81,17 +69,16 @@ export const SearchBar = () => {
             placeholder="Search..."
           />
         </Form.Field>
-        <Form.Field
-          id="SearchButton">
+        <Form.Field id="SearchButton">
           <Button
             primary
-            onSubmit={onSubmit}>
+            onSubmit={onSubmit}
+          >
             <Icon name="search" />
             Search
           </Button>
         </Form.Field>
       </Form.Group>
     </Form>
-
   );
 };

--- a/application/frontend/src/pages/Search/components/SearchResults.tsx
+++ b/application/frontend/src/pages/Search/components/SearchResults.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { DocumentNode } from '../../../components/DocumentNode';
+
+
+  export const SearchResults = ({results}) => (
+    <>
+        {results.length != 0 && results.map((document, i) => (
+            <div key={i} className="accordion ui fluid styled standard-page__links-container">
+                <DocumentNode node={document} linkType={"Standard"}/>
+            </div>
+        ))}
+    </>
+  );

--- a/application/frontend/src/routes.tsx
+++ b/application/frontend/src/routes.tsx
@@ -5,20 +5,14 @@ import { SearchName } from './pages/Search/SearchName';
 import { StandardSection } from './pages/Standard/StandardSection';
 
 export interface IRoute {
-  // The url to this route
   path: string;
-  // What component(s) this will render
   component: ReactNode | ReactNode[];
-  // Whether to show the header on this route
   showHeader: boolean;
 }
 
-export const INDEX = '/';
-export const STANDARD = '/standard';
-export const SECTION = '/section';
-export const SEARCH = '/search';
-export const CRE = '/cre';
-export const GRAPH = '/graph';
+import {
+  INDEX, STANDARD, SECTION, CRE, GRAPH, SEARCH
+} from './const';
 
 export const ROUTES: IRoute[] = [
   {


### PR DESCRIPTION

### What does this PR do?


Fixes the forced window reload that was needed for the searched items to be reloaded.
Minor nits and other refactors and some minor reformatting here and there.
fixes (#83) 

#### Where should the reviewer start?


  - `SearchName.tsx` - this is the most interesting component: what I've changed was to add searchTerm as a dependency of useEffect, which triggers the network call to be made again, hence repopulating the list on results ; renamed `documentsToRender` to `results`, and extracted search results outside the file.
  - `SearchBar.tsx` - minor refactor on the way we were storing the SEARCH_TYPES. so that it's easier to immediately reference any related value (in our case the path).
  - also moved paths into an existing const file from the routes file
