### PR TITLE
Md export

### DIFF
--- a/application/tests/mdutils_test.py
+++ b/application/tests/mdutils_test.py
@@ -5,7 +5,6 @@ import unittest
 from application import create_app, sqla  # type: ignore
 
 
-
 class TestMdutilsParser(unittest.TestCase):
     def tearDown(self) -> None:
         self.app_context.pop()
@@ -17,23 +16,44 @@ class TestMdutilsParser(unittest.TestCase):
         self.app_context.push()
 
     def test_cre_to_md(self) -> None:
-        standards = [defs.Standard(name=f"sname",section=f"section_{s}",hyperlink=f"https://example.com/sname/{s}") for s in range(1,10)]
-        standards2 = [defs.Standard(name=f"sname_other",section=f"section_{s}",hyperlink=f"https://example.com/sname/{s}") for s in range(1,10)]
-        cres = [defs.CRE(name=f"cname_{s}",description=f"description_{s}",
-                         id=f"000-00{s}") for s in range(1,10)]
-        tools = [defs.Tool(name=f"tname_{s}",
-                           tooltype=defs.ToolTypes.Training,
-                           hyperlink=f"https://example.com/tnae/{s}") for s in range(1,10)]
-        
-        for i in range(0,9):
+        standards = [
+            defs.Standard(
+                name=f"sname",
+                section=f"section_{s}",
+                hyperlink=f"https://example.com/sname/{s}",
+            )
+            for s in range(1, 10)
+        ]
+        standards2 = [
+            defs.Standard(
+                name=f"sname_other",
+                section=f"section_{s}",
+                hyperlink=f"https://example.com/sname/{s}",
+            )
+            for s in range(1, 10)
+        ]
+        cres = [
+            defs.CRE(name=f"cname_{s}", description=f"description_{s}", id=f"000-00{s}")
+            for s in range(1, 10)
+        ]
+        tools = [
+            defs.Tool(
+                name=f"tname_{s}",
+                tooltype=defs.ToolTypes.Training,
+                hyperlink=f"https://example.com/tnae/{s}",
+            )
+            for s in range(1, 10)
+        ]
+
+        for i in range(0, 9):
             standards[i].add_link(defs.Link(document=cres[i]))
             if not i % 2:
                 standards[i].add_link(defs.Link(document=tools[i]))
             else:
                 standards[i].add_link(defs.Link(document=standards2[i]))
-        self.maxDiff = None                
+        self.maxDiff = None
         self.assertEqual(mdutils.cre_to_md(standards), self.result)
-        
+
     result = """sname | CRE | tname_1 | sname_other | tname_3 | tname_5 | tname_7 | tname_9
 ----- | --- | ------- | ----------- | ------- | ------- | ------- | -------
 [sname-section_1](https://example.com/sname/1) | [000-001-cname_1](https://www.opencre.org/cre/000-001) | [tname_1](https://example.com/tnae/1) |   |   |   |   |  

--- a/application/tests/mdutils_test.py
+++ b/application/tests/mdutils_test.py
@@ -1,0 +1,48 @@
+from application.utils import mdutils
+from application.defs import cre_defs as defs
+from pprint import pprint
+import unittest
+from application import create_app, sqla  # type: ignore
+
+
+
+class TestMdutilsParser(unittest.TestCase):
+    def tearDown(self) -> None:
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        sqla.create_all(app=self.app)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def test_cre_to_md(self) -> None:
+        standards = [defs.Standard(name=f"sname",section=f"section_{s}",hyperlink=f"https://example.com/sname/{s}") for s in range(1,10)]
+        standards2 = [defs.Standard(name=f"sname_other",section=f"section_{s}",hyperlink=f"https://example.com/sname/{s}") for s in range(1,10)]
+        cres = [defs.CRE(name=f"cname_{s}",description=f"description_{s}",
+                         id=f"000-00{s}") for s in range(1,10)]
+        tools = [defs.Tool(name=f"tname_{s}",
+                           tooltype=defs.ToolTypes.Training,
+                           hyperlink=f"https://example.com/tnae/{s}") for s in range(1,10)]
+        
+        for i in range(0,9):
+            standards[i].add_link(defs.Link(document=cres[i]))
+            if not i % 2:
+                standards[i].add_link(defs.Link(document=tools[i]))
+            else:
+                standards[i].add_link(defs.Link(document=standards2[i]))
+        self.maxDiff = None                
+        self.assertEqual(mdutils.cre_to_md(standards), self.result)
+        
+    result = """sname | CRE | tname_1 | sname_other | tname_3 | tname_5 | tname_7 | tname_9
+----- | --- | ------- | ----------- | ------- | ------- | ------- | -------
+[sname-section_1](https://example.com/sname/1) | [000-001-cname_1](https://www.opencre.org/cre/000-001) | [tname_1](https://example.com/tnae/1) |   |   |   |   |  
+[sname-section_2](https://example.com/sname/2) | [000-002-cname_2](https://www.opencre.org/cre/000-002) |   | [sname_other-section_2](https://example.com/sname/2) |   |   |   |  
+[sname-section_3](https://example.com/sname/3) | [000-003-cname_3](https://www.opencre.org/cre/000-003) |   |   | [tname_3](https://example.com/tnae/3) |   |   |  
+[sname-section_4](https://example.com/sname/4) | [000-004-cname_4](https://www.opencre.org/cre/000-004) |   | [sname_other-section_4](https://example.com/sname/4) |   |   |   |  
+[sname-section_5](https://example.com/sname/5) | [000-005-cname_5](https://www.opencre.org/cre/000-005) |   |   |   | [tname_5](https://example.com/tnae/5) |   |  
+[sname-section_6](https://example.com/sname/6) | [000-006-cname_6](https://www.opencre.org/cre/000-006) |   | [sname_other-section_6](https://example.com/sname/6) |   |   |   |  
+[sname-section_7](https://example.com/sname/7) | [000-007-cname_7](https://www.opencre.org/cre/000-007) |   |   |   |   | [tname_7](https://example.com/tnae/7) |  
+[sname-section_8](https://example.com/sname/8) | [000-008-cname_8](https://www.opencre.org/cre/000-008) |   | [sname_other-section_8](https://example.com/sname/8) |   |   |   |  
+[sname-section_9](https://example.com/sname/9) | [000-009-cname_9](https://www.opencre.org/cre/000-009) |   |   |   |   |   | [tname_9](https://example.com/tnae/9)
+"""

--- a/application/utils/mdutils.py
+++ b/application/utils/mdutils.py
@@ -1,0 +1,53 @@
+from python_markdown_maker import Table, links
+from requests import head
+from application.defs import cre_defs as defs
+from typing import List
+from pprint import pprint
+
+def make_header(documents:List[defs.Document])->List[str]:
+    header = []
+    for doc in documents:
+        name = ""
+        if doc.doctype == defs.Credoctypes.CRE:
+            name = "CRE"
+        else:
+            name = doc.name
+        if name not in header:
+            header.append(doc.name)
+        for link in doc.links:
+            lnkdoc = link.document
+            if lnkdoc.doctype == defs.Credoctypes.CRE:
+                name = "CRE"
+            else:
+                name = lnkdoc.name
+            if name not in header:
+                header.append(name)
+    return header
+
+def cre_to_md(documents:List[defs.Document])->str:
+    header = make_header(documents)
+    result = Table(header)
+    
+    for doc in documents:
+        name = ""
+        if doc.doctype == defs.Credoctypes.CRE:
+            name = "CRE"
+        else:
+            name = doc.name
+        if name not in header:
+            header.append(doc.name)
+
+        item = [" "]*len(header) 
+        item[header.index(doc.name)] = links(doc.hyperlink,f"{doc.name}-{doc.section}")
+        for link in doc.links:
+            lnkdoc = link.document
+            if lnkdoc.doctype == defs.Credoctypes.CRE:
+                item[header.index("CRE")] = links(f"https://www.opencre.org/cre/{lnkdoc.id}",f"{lnkdoc.id} {lnkdoc.name}")        
+            elif lnkdoc.doctype == defs.Credoctypes.Standard:
+                item[header.index(lnkdoc.name)] = links(lnkdoc.hyperlink,f"{lnkdoc.name}-{lnkdoc.section}")
+            elif lnkdoc.doctype == defs.Credoctypes.Tool:
+                item[header.index(lnkdoc.name)] = links(lnkdoc.hyperlink,f"{lnkdoc.name}")
+            elif lnkdoc.doctype == defs.Credoctypes.Code:
+                item[header.index(lnkdoc.name)] = links(lnkdoc.hyperlink,f"{lnkdoc.name}")
+        result.add_item(item)
+    return result.render()

--- a/application/utils/mdutils.py
+++ b/application/utils/mdutils.py
@@ -4,7 +4,8 @@ from application.defs import cre_defs as defs
 from typing import List
 from pprint import pprint
 
-def make_header(documents:List[defs.Document])->List[str]:
+
+def make_header(documents: List[defs.Document]) -> List[str]:
     header = []
     for doc in documents:
         name = ""
@@ -24,10 +25,11 @@ def make_header(documents:List[defs.Document])->List[str]:
                 header.append(name)
     return header
 
-def cre_to_md(documents:List[defs.Document])->str:
+
+def cre_to_md(documents: List[defs.Document]) -> str:
     header = make_header(documents)
     result = Table(header)
-    
+
     for doc in documents:
         name = ""
         if doc.doctype == defs.Credoctypes.CRE:
@@ -37,17 +39,26 @@ def cre_to_md(documents:List[defs.Document])->str:
         if name not in header:
             header.append(doc.name)
 
-        item = [" "]*len(header) 
-        item[header.index(doc.name)] = links(doc.hyperlink,f"{doc.name}-{doc.section}")
+        item = [" "] * len(header)
+        item[header.index(doc.name)] = links(doc.hyperlink, f"{doc.name}-{doc.section}")
         for link in doc.links:
             lnkdoc = link.document
             if lnkdoc.doctype == defs.Credoctypes.CRE:
-                item[header.index("CRE")] = links(f"https://www.opencre.org/cre/{lnkdoc.id}",f"{lnkdoc.id} {lnkdoc.name}")        
+                item[header.index("CRE")] = links(
+                    f"https://www.opencre.org/cre/{lnkdoc.id}",
+                    f"{lnkdoc.id} {lnkdoc.name}",
+                )
             elif lnkdoc.doctype == defs.Credoctypes.Standard:
-                item[header.index(lnkdoc.name)] = links(lnkdoc.hyperlink,f"{lnkdoc.name}-{lnkdoc.section}")
+                item[header.index(lnkdoc.name)] = links(
+                    lnkdoc.hyperlink, f"{lnkdoc.name}-{lnkdoc.section}"
+                )
             elif lnkdoc.doctype == defs.Credoctypes.Tool:
-                item[header.index(lnkdoc.name)] = links(lnkdoc.hyperlink,f"{lnkdoc.name}")
+                item[header.index(lnkdoc.name)] = links(
+                    lnkdoc.hyperlink, f"{lnkdoc.name}"
+                )
             elif lnkdoc.doctype == defs.Credoctypes.Code:
-                item[header.index(lnkdoc.name)] = links(lnkdoc.hyperlink,f"{lnkdoc.name}")
+                item[header.index(lnkdoc.name)] = links(
+                    lnkdoc.hyperlink, f"{lnkdoc.name}"
+                )
         result.add_item(item)
     return result.render()

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -9,6 +9,7 @@ from application import cache
 from application.database import db
 from application.defs import cre_defs as defs
 from application.defs import osib_defs as odefs
+from application.utils import mdutils
 from flask import (
     Blueprint,
     abort,
@@ -72,6 +73,7 @@ def find_node_by_name(name: str, ntype: str = defs.Credoctypes.Standard.value) -
     opt_section = request.args.get("section")
     opt_osib = request.args.get("osib")
     opt_version = request.args.get("version")
+    opt_mdformat = request.args.get("format_md")
     if opt_section:
         opt_section = urllib.parse.unquote(opt_section)
     opt_subsection = request.args.get("subsection")
@@ -105,6 +107,8 @@ def find_node_by_name(name: str, ntype: str = defs.Credoctypes.Standard.value) -
     result["total_pages"] = total_pages
     result["page"] = page
     if nodes:
+        if opt_mdformat:
+            return mdutils.cre_to_md(nodes)
         if opt_osib:
             result["osib"] = odefs.cre2osib(nodes).todict()
         res = [node.todict() for node in nodes]

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -50,7 +50,7 @@ def find_cre(creid: str = None, crename: str = None) -> Any:  # refer
     database = db.Node_collection()
     include_only = request.args.getlist("include_only")
     opt_osib = request.args.get("osib")
-
+    opt_md = request.args.get("format_md")
     cres = database.get_CREs(external_id=creid, name=crename, include_only=include_only)
     if cres:
         if len(cres) > 1:
@@ -61,6 +61,8 @@ def find_cre(creid: str = None, crename: str = None) -> Any:  # refer
         # cre = extend_cre_with_tag_links(cre=cre, collection=database)
         if opt_osib:
             result["osib"] = odefs.cre2osib([cre]).todict()
+        if opt_md:
+            return mdutils.cre_to_md([cre])
         return jsonify(result)
     abort(404)
 
@@ -124,12 +126,15 @@ def find_document_by_tag() -> Any:
     database = db.Node_collection()
     tags = request.args.getlist("tag")
     opt_osib = request.args.get("osib")
+    opt_md = request.args.get("format_md")
     documents = database.get_by_tags(tags)
     if documents:
         res = [doc.todict() for doc in documents]
         result = {"data": res}
         if opt_osib:
             result["osib"] = odefs.cre2osib(documents).todict()
+        if opt_md:
+            return mdutils.cre_to_md(documents)
         return jsonify(result)
     abort(404)
 
@@ -161,8 +166,11 @@ def text_search() -> Any:
     """
     database = db.Node_collection()
     text = request.args.get("text")
+    opt_md = reques.args.get("format_md")
     documents = database.text_search(text)
     if documents:
+        if opt_md:
+            return mdutils.cre_to_md(documents)
         res = [doc.todict() for doc in documents]
         return jsonify(res)
     else:
@@ -174,12 +182,15 @@ def find_root_cres() -> Any:
     """Useful for fast browsing the graph from the top"""
     database = db.Node_collection()
     opt_osib = request.args.get("osib")
+    opt_md = request.args.get("format_md")
     documents = database.get_root_cres()
     if documents:
         res = [doc.todict() for doc in documents]
         result = {"data": res}
         if opt_osib:
             result["osib"] = odefs.cre2osib(documents).todict()
+        if opt_md:
+            return mdutils.cre_to_md(documents)
         return jsonify(result)
     abort(404)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ PyJWT==1.7.1
 pyparsing==2.4.6
 pyrsistent==0.17.3
 python-dateutil==2.8.1
+python-markdown-maker==1.0
 PyYAML==5.3.1
 regex==2021.11.10
 requests==2.27.1


### PR DESCRIPTION
adds the ability to export the cre results in markdown table format by supplying any api call with `?format_md=true`
e.g.
`curl http://localhost:5000/rest/v1/standard/ASVS\?format_md\=true > test.md`
produces a markdown table with all the mappings between ASVS and CRE