### PR TITLE
Parse capec

### DIFF
--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -15,6 +15,7 @@ from application.defs import osib_defs as odefs
 from application.utils import spreadsheet as sheet_utils
 from application.utils import spreadsheet_parsers
 from application.utils.external_project_parsers import (
+    capec_parser,
     cheatsheets_parser,
     misc_tools_parser,
     zap_alerts_parser,
@@ -366,6 +367,8 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
             misc_tools_parser.parse_tool(
                 cache=db_connect(args.cache_file), tool_repo=url
             )
+    if args.capec_in:
+        capec_parser.parse_capec(cache=db_connect(args.cache_file))
     if args.owasp_proj_meta:
         owasp_metadata_to_cre(args.owasp_proj_meta)
 

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -490,6 +490,10 @@ class Node_collection:
                 linked_cres = Links.query.filter(Links.node == dbnode.id).all()
                 for dbcre_link in linked_cres:
                     dbcre = CRE.query.filter(CRE.id == dbcre_link.cre).first()
+                    if not dbcre:
+                        logger.fatal(
+                            f"CRE {dbcre_link.cre} exists in the links but not in the cre table, database corrupt?"
+                        )
                     if not include_only or (
                         include_only
                         and (

--- a/application/tests/capec_parser_test.py
+++ b/application/tests/capec_parser_test.py
@@ -1,0 +1,94 @@
+from application.defs import cre_defs as defs
+import unittest
+from application import create_app, sqla  # type: ignore
+from application.database import db
+import tempfile
+import os
+
+from application.utils.external_project_parsers import capec_parser
+
+
+class TestCapecParser(unittest.TestCase):
+    def tearDown(self) -> None:
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        sqla.create_all(app=self.app)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        self.collection = db.Node_collection()
+
+    def test_register_capec(self) -> None:
+        fd, fname = tempfile.mkstemp()
+        with os.fdopen(fd=fd, mode="w") as xml:
+            xml.write(self.capec_xml)
+        cres = []
+        for cwe in [276, 285, 434]:
+            dbnode = self.collection.add_node(defs.Standard(name="CWE", section=cwe))
+            cre = defs.CRE(id=f"{cwe}-{cwe}", name=f"CRE-{cwe}")
+            cres.append(cre)
+            dbcre = self.collection.add_cre(cre=cre)
+            self.collection.add_link(cre=dbcre, node=dbnode)
+        capec_parser.register_capec(cache=self.collection, xml_file=fname)
+
+        expected = defs.Standard(
+            name="CAPEC",
+            doctype=defs.Credoctypes.Standard,
+            links=[
+                defs.Link(document=defs.CRE(name="CRE-276", id="276-276")),
+                defs.Link(document=defs.CRE(name="CRE-285", id="285-285")),
+                defs.Link(document=defs.CRE(name="CRE-434", id="434-434")),
+            ],
+            hyperlink="https://capec.mitre.org/data/definitions/1.html",
+            section="1",
+            subsection="Accessing Functionality Not Properly Constrained by ACLs",
+            version="3.7",
+        )
+
+        node = self.collection.get_nodes(
+            name="CAPEC",
+            section="1",
+            subsection="Accessing Functionality Not Properly Constrained by ACLs",
+        )[0]
+        self.assertEquals(node, expected)
+
+    capec_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<Attack_Pattern_Catalog xmlns="http://capec.mitre.org/capec-3"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:capec="http://capec.mitre.org/capec-3"
+                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                        Name="CAPEC"
+                        Version="3.7"
+                        Date="2022-02-22"
+                        xsi:schemaLocation="http://capec.mitre.org/capec-3 http://capec.mitre.org/data/xsd/ap_schema_v3.5.xsd">
+   <Attack_Patterns>
+      <Attack_Pattern ID="1" Name="Accessing Functionality Not Properly Constrained by ACLs"
+                      Abstraction="Standard"
+                      Status="Stable"> 
+         <Related_Weaknesses>
+            <Related_Weakness CWE_ID="276"/>
+            <Related_Weakness CWE_ID="285"/>
+            <Related_Weakness CWE_ID="434"/>
+            <Related_Weakness CWE_ID="693"/>
+            <Related_Weakness CWE_ID="732"/>
+            <Related_Weakness CWE_ID="1193"/>
+            <Related_Weakness CWE_ID="1220"/>
+            <Related_Weakness CWE_ID="1297"/>
+            <Related_Weakness CWE_ID="1311"/>
+            <Related_Weakness CWE_ID="1314"/>
+            <Related_Weakness CWE_ID="1315"/>
+            <Related_Weakness CWE_ID="1318"/>
+            <Related_Weakness CWE_ID="1320"/>
+            <Related_Weakness CWE_ID="1321"/>
+            <Related_Weakness CWE_ID="1327"/>
+         </Related_Weaknesses>
+      </Attack_Pattern>
+         <Attack_Pattern ID="10" Name="Accessing Functionality Not Properly Constrained by ACLs"
+                      Abstraction="Standard"
+                      Status="Stable"> 
+         <Related_Weaknesses>
+         </Related_Weaknesses>
+      </Attack_Pattern>
+   </Attack_Patterns>
+</Attack_Pattern_Catalog>"""

--- a/application/utils/external_project_parsers/capec_parser.py
+++ b/application/utils/external_project_parsers/capec_parser.py
@@ -21,11 +21,12 @@ def parse_capec(cache: db.Node_collection):
     xml = requests.get(capec_xml)
     if xml.status_code == 200:
         handle, fname = tempfile.mkstemp(suffix=".xml")
-        with os.fdopen(handle,'w') as xmlfile:
+        with os.fdopen(handle, "w") as xmlfile:
             xmlfile.write(xml.text)
         register_capec(xml_file=fname, cache=cache)
     else:
         logger.fatal(f"Could not get CAPEC's XML data, error was {xml.text}")
+
 
 def make_hyperlink(capec_id: int):
     return f"https://capec.mitre.org/data/definitions/{capec_id}.html"
@@ -39,7 +40,9 @@ def link_capec_to_cwe_cre(capec: db.Node, cache: db.Node_collection, cwe_id: str
             for c in cwes[0].links
             if c.document.doctype == defs.Credoctypes.CRE
         ]:
-            logger.debug(f"linked CAPEC with id {capec.section} to CRE with ID {cre.id}")
+            logger.debug(
+                f"linked CAPEC with id {capec.section} to CRE with ID {cre.id}"
+            )
             cache.add_link(cre=db.dbCREfromCRE(cre), node=capec)
 
 
@@ -79,4 +82,6 @@ def register_capec(cache: db.Node_collection, xml_file: str):
                                     capec=dbcapec, cache=cache, cwe_id=id
                                 )
                 else:
-                    logger.error(f"CAPEC {capec.section} does not have any related CWE weaknesses, skipping automated linking")
+                    logger.error(
+                        f"CAPEC {capec.section} does not have any related CWE weaknesses, skipping automated linking"
+                    )

--- a/application/utils/external_project_parsers/capec_parser.py
+++ b/application/utils/external_project_parsers/capec_parser.py
@@ -1,0 +1,82 @@
+import imp
+import logging
+import os
+import tempfile
+import requests
+from typing import Dict, Iterable, List
+import untangle
+from application.database import db
+from application.defs import cre_defs as defs
+from application.utils import git
+
+from pprint import pp, pprint
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def parse_capec(cache: db.Node_collection):
+    capec_xml = "https://capec.mitre.org/data/xml/capec_latest.xml"
+    xml = requests.get(capec_xml)
+    if xml.status_code == 200:
+        handle, fname = tempfile.mkstemp(suffix=".xml")
+        with os.fdopen(handle,'w') as xmlfile:
+            xmlfile.write(xml.text)
+        register_capec(xml_file=fname, cache=cache)
+    else:
+        logger.fatal(f"Could not get CAPEC's XML data, error was {xml.text}")
+
+def make_hyperlink(capec_id: int):
+    return f"https://capec.mitre.org/data/definitions/{capec_id}.html"
+
+
+def link_capec_to_cwe_cre(capec: db.Node, cache: db.Node_collection, cwe_id: str):
+    cwes = cache.get_nodes(name="CWE", section=cwe_id)
+    if cwes:
+        for cre in [
+            c.document
+            for c in cwes[0].links
+            if c.document.doctype == defs.Credoctypes.CRE
+        ]:
+            logger.debug(f"linked CAPEC with id {capec.section} to CRE with ID {cre.id}")
+            cache.add_link(cre=db.dbCREfromCRE(cre), node=capec)
+
+
+def register_capec(cache: db.Node_collection, xml_file: str):
+    attack_pattern_catalogue = {}
+    import xmltodict
+
+    with open(xml_file) as xml:
+        attack_pattern_catalogue = xmltodict.parse(xml.read()).get(
+            "Attack_Pattern_Catalog"
+        )
+        version = attack_pattern_catalogue["@Version"]
+    for _, attack_pattern in attack_pattern_catalogue.get("Attack_Patterns").items():
+        for pattern in attack_pattern:  # attack_pattern is an array with 1 element
+            if pattern["@Status"] == "Stable":
+                capec = defs.Standard(
+                    name="CAPEC",
+                    section=pattern["@ID"],
+                    subsection=pattern["@Name"],
+                    hyperlink=make_hyperlink(pattern["@ID"]),
+                    version=version,
+                )
+                dbcapec = cache.add_node(capec)
+                logger.debug(f"Registered CAPEC with id {capec.section}")
+                if pattern.get("Related_Weaknesses"):
+                    for lst in pattern["Related_Weaknesses"].values():
+                        for cwe_entry in lst:
+                            if isinstance(cwe_entry, Dict):
+                                for _, cwe_id in cwe_entry.items():
+
+                                    link_capec_to_cwe_cre(
+                                        capec=dbcapec, cache=cache, cwe_id=cwe_id
+                                    )
+                            else:
+                                id = lst["@CWE_ID"]
+                                link_capec_to_cwe_cre(
+                                    capec=dbcapec, cache=cache, cwe_id=id
+                                )
+                else:
+                    logger.error(f"CAPEC {capec.section} does not have any related CWE weaknesses, skipping automated linking")

--- a/cre.py
+++ b/cre.py
@@ -132,6 +132,12 @@ def main() -> None:
         action="store_true",
         help="import supported github tools, urls can be found in misc_tools_parser.py",
     )
+    parser.add_argument(
+        "--capec_in",
+        action="store_true",
+        help="import CAPEC",
+    )
+
     args = parser.parse_args()
 
     from application.cmd import cre_main


### PR DESCRIPTION
add command line option --capec_in and relevant parser which downloads the latest capec xml from "https://capec.mitre.org/data/xml/capec_latest.xml", parses the attack patterns and for the ones we have known CWE ids , links them to CREs.

If there are no known CWE ids related to a CAPEC entry, an error is printed and the parsing continues silently adding a non-linked entry