### PR TITLE
Fix cheatsheet import

### DIFF
--- a/.github/workflows/auto-import.yml
+++ b/.github/workflows/auto-import.yml
@@ -1,0 +1,27 @@
+name: AutoImport
+on: 
+  workflow_dispatch: # allow manual triggering
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+jobs:
+  backup:
+    environment: Heroku-DB-Backup
+    name: Import latest dataset to Heroku
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refresh Data
+        env: 
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          make install
+          source venv/bin/activate
+          make migrate-upgrade
+          make import-all
+          rm -rf dbdump && sqlite3 standards_cache.sqlite .dump > dbdump
+          tmp=$(cat dbdump | grep -v "BEGIN TRANSACTION;" | grep -v "PRAGMA foreign_keys=OFF;")
+          tmp=$(echo "DROP TABLE cre CASCADE; " "DROP TABLE node CASCADE;" "DROP TABLE alembic_version CASCADE;" "DROP TABLE cre_node_links CASCADE;" "DROP TABLE cre_links CASCADE;"; echo "${tmp}")
+          rm -rf dbtmp && echo $tmp >dbtmp
+          heroku pg:psql < dbtmp

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ cover:
 
 install-deps:
 	[ -d "./venv" ] && . ./venv/bin/activate 
-	pip install -r requirements.txt& yarn install
+	pip install -r requirements.txt
+	yarn install
 
 install:
 	virtualenv -p python3 venv && . ./venv/bin/activate && make install-deps && yarn build

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,15 @@ clean:
 	find . -type f -name '*.log' -delete
 	find . -type f -name '*.orig' -delete
 
-migrate-upgrade:
+migrate-restore:
 	if ! [ -f "standards_cache.sqlite" ]; then cp cres/db.sqlite standards_cache.sqlite; fi
 	[ -d "./venv" ] && . ./venv/bin/activate
-	export FLASK_APP=$(CURDIR)/cre.py
+	export FLASK_APP=$(CURDIR)/cre.py 
+	flask db upgrade  
+
+migrate-upgrade:
+	[ -d "./venv" ] && . ./venv/bin/activate
+	export FLASK_APP=$(CURDIR)/cre.py 
 	flask db upgrade  
 
 migrate-downgrade:
@@ -67,7 +72,10 @@ migrate-downgrade:
 
 import-all:
 	[ -d "./venv" ] && . ./venv/bin/activate
+	rm -rf standards_cache.sqlite
+	make migrate-upgrade
 	export FLASK_APP=$(CURDIR)/cre.py
-	python cre.py --add --from_spreadsheet https://docs.google.com/spreadsheets/d/1eZOEYgts7d_-Dr-1oAbogPfzBLh6511b58pX3b59kvg/edit#gid=260321921 --zap_in --cheatsheets_in --github_tools_in --capec_in
+	python cre.py --add --from_spreadsheet https://docs.google.com/spreadsheets/d/1eZOEYgts7d_-Dr-1oAbogPfzBLh6511b58pX3b59kvg/edit#gid=260321921 
+	python cre.py --zap_in --cheatsheets_in --github_tools_in  --capec_in
 
 all: clean lint test dev dev-run

--- a/application/utils/spreadsheet_parsers.py
+++ b/application/utils/spreadsheet_parsers.py
@@ -547,7 +547,8 @@ def parse_hierarchical_export_format(
                     )
                 )
 
-        [cre.add_link(link) for link in parse_standards(mapping)]
+        for link in parse_standards(mapping):
+            cre.add_link(link)
 
         # link CRE to a higher level one
 


### PR DESCRIPTION
this is a small but important one:

- [x] add a github action to import data from all sources and replace the heroku database with the freshly imported data
- [x] add `make migrate-restore` target to restore the latest dataset from cres/db.sqlite
- [x] change `make migrate-upgrade` to just provide the latest db migrations instead of migrations and data
